### PR TITLE
Move JSON Conversion

### DIFF
--- a/automation.ps1
+++ b/automation.ps1
@@ -65,13 +65,12 @@ Function Update-ManifestAndJson ($PackageIdentifier, $PackageVersion, $Installer
     Write-Host -ForegroundColor Green "----------------------------------------------------"
 }
 
-$packages = $(Get-ChildItem .\packages\ -Recurse -File).FullName
+$packages = Get-ChildItem .\packages\ -Recurse -File | Get-Content -raw | ConvertFrom-Json
 $urls = [System.Collections.ArrayList]::new()
 $i = 0
 $cnt = $packages.Count
-foreach ($json in $packages) {
+foreach ($package in $packages) {
     $i++
-    $package = Get-Content $json | ConvertFrom-Json
     $urls.Clear()
     if ($package.skip -eq $false -and $package.custom_script -eq $false)
     {


### PR DESCRIPTION
@vedantmgoyal2009 This moves the JSON conversion up

This change allows for filtering manifests out in batches before processing them. For example:
```powershell
# Filters out all the packages to skip without ever checking them
$packages = $packages | Where-Object {$_.Skip -eq $false}
```

This would make things like #70 easier to implement, since it makes the properties are available before entering the for loop (meaning you don't have to check every package individually to see if it passes a filter)