### PR TITLE
Feature: Automatically mark packages as stale

### DIFF
--- a/automation.ps1
+++ b/automation.ps1
@@ -126,7 +126,7 @@ foreach ($package in $packages)
             # If the last release was more than 6 months ago, automatically add it to the skip list
             # 3600 secs/hr * 24 hr/day * 180 days = 15552000
             if (([DateTimeOffset]::Now.ToUnixTimeSeconds()-15552000) -ge [DateTimeOffset]::new($result.published_at).ToUnixTimeSeconds()){
-                $package.skip = 'Not updated for a long period'
+                $package.skip = 'Automatically marked as stale, not updated for 6 months'
             }
         }
     }


### PR DESCRIPTION
I chose 6 months kind of at random, but I figured that if it was updated less frequently than that, there really isn't a point in automating it. This could potentially be reduced or increased in the future, but I figured I'd at least throw the idea out there
