### PR TITLE
fix: switch R url to a permanent one

### DIFF
--- a/package_scripts/r/rproject.r.ps1
+++ b/package_scripts/r/rproject.r.ps1
@@ -4,7 +4,7 @@ if ($result -gt $package.last_checked_tag)
     $update_found = $true
     $version = $result
     $jsonTag = $result
-    $urls.Add("https://cran.microsoft.com/bin/windows/base/R-$version-win.exe") | Out-Null
+    $urls.Add("https://cloud.r-project.org/bin/windows/base/old/$version/R-$version-win.exe") | Out-Null
 }
 else
 {


### PR DESCRIPTION
- [x] Have you verified that a previous version of the package is already there in the [Windows Package Manager Community Repository](https://github.com/microsoft/winget-pkgs)?
- [x] Have you validated the JSON with the [JSON Schema](https://raw.githubusercontent.com/vedantmgoyal2009/winget-pkgs-automation/main/schema.json)?
- [x] Have you verified that the values entered in the JSON are correct?
- [x] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines

Related to https://github.com/microsoft/winget-pkgs/pull/36973

The URL currently in use will eventually be removed, as in https://github.com/microsoft/winget-pkgs/pull/35010, because it only works during the latest version.