### PR TITLE
Fixing outdated ruby version

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -11,6 +11,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
       - run: gem install jwt openssl --no-doc
       - name: Run automation script
         shell: pwsh


### PR DESCRIPTION
The `windows-latest` has an outdated ruby version. I use https://github.com/ruby/setup-ruby to get the newest version