### PR TITLE
fix: lostdesign.linked regex

### DIFF
--- a/packages/l/lostdesign.linked.json
+++ b/packages/l/lostdesign.linked.json
@@ -3,7 +3,7 @@
   "pkgid": "lostdesign.linked",
   "repo_uri": "lostdesign/linked",
   "last_checked_tag": "58510515",
-  "asset_regex": ".(exe|msi|msix|appx)(bundle){0,1}$",
+  "asset_regex": "linked-Setup-*.exe$",
   "is_prerelease": false,
   "version_method": null,
   "use_package_script": false,

--- a/packages/l/lostdesign.linked.json
+++ b/packages/l/lostdesign.linked.json
@@ -3,7 +3,7 @@
   "pkgid": "lostdesign.linked",
   "repo_uri": "lostdesign/linked",
   "last_checked_tag": "58510515",
-  "asset_regex": "linked-Setup-*.exe$",
+  "asset_regex": "linked-Setup-.*\\.exe$",
   "is_prerelease": false,
   "version_method": null,
   "use_package_script": false,


### PR DESCRIPTION
according to other files this seems correct? 🤔

- [X] Have you verified that a previous version of the package is already there in the [Windows Package Manager Community Repository](https://github.com/microsoft/winget-pkgs)?
  * https://github.com/microsoft/winget-pkgs/pull/44318
- [ ] Have you validated the JSON with the [JSON Schema](https://raw.githubusercontent.com/vedantmgoyal2009/winget-pkgs-automation/main/schema.json)?
- [X] Have you verified that the values entered in the JSON are correct?
- [X] The commit message follows the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) guidelines.
